### PR TITLE
Remove incorrect test case

### DIFF
--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -59,13 +59,8 @@ class RoutesCommandTest extends TestCase
         $this->get('items/1');
         $this->assertResponseCode(200);
 
-        // test  Riesenia\Core plugin attribute with api scope
-        $this->configRequest(['headers' => ['Accept' => 'application/json']]);
-        $this->get('api/authors');
-        $this->assertResponseCode(200);
-
         $body = \json_decode($this->_getBodyAsString(), true);
-        $this->assertEquals(2, \count($body));
+        $this->assertEquals(4, \count($body));
         $this->assertResponseCode(200);
 
         $this->configRequest(['headers' => ['Accept' => 'application/json']]);


### PR DESCRIPTION
The test case was trying to fetch from an endpoint that required an id parameter without providing said id. This broke in f58861f because we started adding the route parameters to the route definition.